### PR TITLE
Strip punctuation from beginning of vcc function names.

### DIFF
--- a/src/vcc.rs
+++ b/src/vcc.rs
@@ -195,15 +195,22 @@ fn parse_func<'a>(
 ) -> Func {
     let r#return = parse_type(toks).map(Box::new);
 
-    let name = toks.next().unwrap().to_string();
+    let func_name = toks.next().unwrap().to_string();
+    let func_name_without_prefix = match func_name.as_str().get(..1) {
+        Some(".") => func_name[1..].to_owned(),
+        None => panic!("invalid VCC function"),
+        _ => func_name.to_owned()
+    };
+
     assert_eq!(toks.next(), Some("("), "expected arguments");
 
     let args = parse_func_args(toks);
     // assert_eq!(toks.next(), Some(")"), "expected end of arguments");
     let doc = parse_doc(lines_iter);
 
+
     Func {
-        name,
+        name: func_name_without_prefix,
         r#return,
         args,
         doc: Some(doc),


### PR DESCRIPTION
In some cases vcc function names is parsed with a punctuation in front. This breaks autocomplete in vscode. my_goto_backend.backend() completes as my_goto_backend..backend() etc.

This change removes the punctuation from the start of function names if there is one before adding it to the list of vcc functions.