### PR TITLE
Update tree-sitter-cli for Apple Silicon builds

### DIFF
--- a/vendor/tree-sitter-vcl/package-lock.json
+++ b/vendor/tree-sitter-vcl/package-lock.json
@@ -9,20 +9,20 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "nan": "^2.17.0",
-        "tree-sitter-cli": "^0.20.7"
+        "nan": "^2.22.0",
+        "tree-sitter-cli": "^0.22.6"
       }
     },
     "node_modules/nan": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
+      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
       "dev": true
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.20.7",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.7.tgz",
-      "integrity": "sha512-MHABT8oCPr4D0fatsPo6ATQ9H4h9vHpPRjlxkxJs80tpfAEKGn6A1zU3eqfCKBcgmfZDe9CiL3rKOGMzYHwA3w==",
+      "version": "0.22.6",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.22.6.tgz",
+      "integrity": "sha512-s7mYOJXi8sIFkt/nLJSqlYZP96VmKTc3BAwIX0rrrlRxWjWuCwixFqwzxWZBQz4R8Hx01iP7z3cT3ih58BUmZQ==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {

--- a/vendor/tree-sitter-vcl/package.json
+++ b/vendor/tree-sitter-vcl/package.json
@@ -10,8 +10,8 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "nan": "^2.17.0",
-    "tree-sitter-cli": "^0.20.7"
+    "nan": "^2.22.0",
+    "tree-sitter-cli": "^0.22.6"
   },
   "tree-sitter": [
     {

--- a/vendor/tree-sitter-vtc/package-lock.json
+++ b/vendor/tree-sitter-vtc/package-lock.json
@@ -9,20 +9,20 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "nan": "^2.17.0",
-        "tree-sitter-cli": "^0.20.7"
+        "nan": "^2.22.0",
+        "tree-sitter-cli": "^0.22.6"
       }
     },
     "node_modules/nan": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
+      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
       "dev": true
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.20.8",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.8.tgz",
-      "integrity": "sha512-XjTcS3wdTy/2cc/ptMLc/WRyOLECRYcMTrSWyhZnj1oGSOWbHLTklgsgRICU3cPfb0vy+oZCC33M43u6R1HSCA==",
+      "version": "0.22.6",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.22.6.tgz",
+      "integrity": "sha512-s7mYOJXi8sIFkt/nLJSqlYZP96VmKTc3BAwIX0rrrlRxWjWuCwixFqwzxWZBQz4R8Hx01iP7z3cT3ih58BUmZQ==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {

--- a/vendor/tree-sitter-vtc/package.json
+++ b/vendor/tree-sitter-vtc/package.json
@@ -10,8 +10,8 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "nan": "^2.17.0",
-    "tree-sitter-cli": "^0.20.7"
+    "nan": "^2.22.0",
+    "tree-sitter-cli": "^0.22.6"
   },
   "tree-sitter": [
     {


### PR DESCRIPTION
This updates the Node package versions.

- `tree-sitter-cli` specifically to fix build failures on Apple Silicon per https://github.com/tree-sitter/tree-sitter/issues/2009. With the current version, I get the below error locally. With the updated version, I am able to build. Only going to `0.22.X` as newer versions introduce other build failures.

```
❯ make tree-sitter-vcl tree-sitter-vtc
cd vendor/tree-sitter-vcl && npm ci && npm run build

added 2 packages, and audited 3 packages in 30s

found 0 vulnerabilities

> tree-sitter-vcl@1.0.0 build
> tree-sitter generate

node:internal/child_process:421
    throw new ErrnoException(err, 'spawn');
    ^

Error: spawn Unknown system error -86
    at ChildProcess.spawn (node:internal/child_process:421:11)
    at spawn (node:child_process:761:9)
    at Object.<anonymous> (/Users/duffn/code/varnishls/vendor/tree-sitter-vcl/node_modules/tree-sitter-cli/cli.js:8:1)
    at Module._compile (node:internal/modules/cjs/loader:1376:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
    at Module.load (node:internal/modules/cjs/loader:1207:32)
    at Module._load (node:internal/modules/cjs/loader:1023:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:135:12)
    at node:internal/main/run_main_module:28:49 {
  errno: -86,
  code: 'Unknown system error -86',
  syscall: 'spawn'
}

Node.js v21.4.0
make: *** [tree-sitter-vcl] Error 1
```

- `nan` just bumping the version to the latest