### PR TITLE
Add ok keyword

### DIFF
--- a/vendor/tree-sitter-vcl/grammar.js
+++ b/vendor/tree-sitter-vcl/grammar.js
@@ -306,6 +306,7 @@ module.exports = grammar({
           'error',
           'purge',
           'fetch',
+          'ok',
         ),
         optional(seq('(', optional(commaSep($.expr)), ')')),
       ),

--- a/vendor/tree-sitter-vcl/queries/highlights.scm
+++ b/vendor/tree-sitter-vcl/queries/highlights.scm
@@ -31,6 +31,7 @@
   "deliver"
   "abandon"
   "lookup"
+  "ok"
 ] @keyword
 
 (operator) @operator

--- a/vendor/tree-sitter-vcl/queries/semantic_tokens.scm
+++ b/vendor/tree-sitter-vcl/queries/semantic_tokens.scm
@@ -32,6 +32,7 @@
   "deliver"
   "abandon"
   "lookup"
+  "ok"
 ] @keyword
 
 (operator) @operator


### PR DESCRIPTION
This adds the `ok` keyword. `ok` is a valid VCL keyword: https://www.varnish-software.com/developers/tutorials/varnish-builtin-vcl/#14-vcl_fini

The update results in no longer calling `ok` a syntax error in a block such as this.

```
sub vcl_fini {
    return (ok);
}
```