### PR TITLE
Update for latest stable Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,6 +443,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,13 +824,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.31"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
  "libc",
+ "num-conv",
  "num_threads",
  "powerfmt",
  "serde",
@@ -840,10 +847,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -1725,9 +1725,7 @@ fn get_toplev_declaration_from_node(node: Node) -> Node {
 fn find_parent(node: Node, kind: String) -> Option<Node> {
     let mut node = node;
     loop {
-        let Some(parent_node) = node.parent() else {
-            return None;
-        };
+        let parent_node = node.parent()?;
         node = parent_node;
         if node.kind() == kind {
             return Some(node);

--- a/src/varnish_builtins.rs
+++ b/src/varnish_builtins.rs
@@ -99,7 +99,7 @@ pub struct AutocompleteSearchOptions {
 
 impl Definitions {
     pub fn get(&self, ident: &str) -> Option<&Definition> {
-        self.properties.get(&ident.to_string())
+        self.properties.get(ident)
     }
 
     pub fn get_type_property_by_nested_idents(&self, idents: Vec<&str>) -> Option<&Type> {
@@ -162,9 +162,7 @@ impl HasTypeProperties for Definitions {
             .collect()
     }
     fn get_type_property(&self, ident: &str) -> Option<&Type> {
-        self.properties
-            .get(&ident.to_string())
-            .map(|def| &(*def.r#type))
+        self.properties.get(ident).map(|def| &(*def.r#type))
     }
     fn obj(&self) -> Option<&Obj> {
         None
@@ -213,7 +211,7 @@ impl HasTypeProperties for Obj {
         if self.is_http_headers {
             return Some(&Type::String);
         }
-        self.properties.get(&ident.to_string())
+        self.properties.get(ident)
     }
     fn obj(&self) -> Option<&Obj> {
         Some(self)

--- a/src/vcc.rs
+++ b/src/vcc.rs
@@ -257,9 +257,7 @@ fn parse_func_args<'a>(toks: &mut Peekable<impl Iterator<Item = &'a str>>) -> Ve
 }
 
 fn check_restrict<'a>(parts: &mut Peekable<impl Iterator<Item = &'a str>>) -> Option<Vec<String>> {
-    let Some(next_part) = parts.peek() else {
-        return None;
-    };
+    let next_part = parts.peek()?;
     if next_part.starts_with("Restrict ") {
         Some(
             parts.next().unwrap()["Restrict ".len()..]


### PR DESCRIPTION
This fixes the repo for the latest stable Rust. 

- The `time` package update is for https://github.com/duffn/varnishls/actions/runs/11636450820/job/32407877899?pr=1

```
 error[E0282]: type annotations needed for `Box<_>`
  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/time-0.3.31/src/format_description/parse/mod.rs:83:9
   |
83 |     let items = format_items
   |         ^^^^^
...
86 |     Ok(items.into())
   |              ---- type must be known at this point
   |
   = note: this is an inference error on crate `time` caused by an API change in Rust 1.80.0; update `time` to version `>=0.3.35` by calling `cargo update`
```

- The code updates are for various Clippy warnings https://github.com/duffn/varnishls/actions/runs/11636474642/job/32407946214?pr=1