### PR TITLE
Add body

### DIFF
--- a/src/varnish_builtins.rs
+++ b/src/varnish_builtins.rs
@@ -29,6 +29,7 @@ pub enum Type {
     Enum(Vec<String>),
     Blob,
     IP,
+    Body,
 }
 
 impl Type {
@@ -74,6 +75,7 @@ impl std::fmt::Display for Type {
             Type::Enum(values) => write!(f, "ENUM {{{}}}", values.join(", ")),
             Type::Blob => write!(f, "BLOB"),
             Type::IP => write!(f, "IP"),
+            Type::Body => write!(f, "BODY"),
         }
     }
 }
@@ -424,6 +426,7 @@ pub fn get_varnish_builtins() -> Definitions {
             ("backend".to_string(), Type::Backend),
             ("uncacheable".to_string(), Type::Bool),
             ("is_bgfetch".to_string(), Type::Bool),
+            ("body".to_string(), Type::Body),
         ]),
         ..Obj::default()
     });
@@ -450,6 +453,7 @@ pub fn get_varnish_builtins() -> Definitions {
             ("reason".to_string(), Type::String),
             ("backend".to_string(), Type::Backend),
             ("is_streaming".to_string(), Type::Bool),
+            ("body".to_string(), Type::Body),
         ]),
         ..Obj::default()
     });
@@ -484,6 +488,7 @@ pub fn get_varnish_builtins() -> Definitions {
             ("keep".to_string(), Type::Duration),
             // ("storage".to_string(), Type::String),
             ("storage_hint".to_string(), Type::String),
+            ("body".to_string(), Type::Body),
         ]),
         ..Obj::default()
     });


### PR DESCRIPTION
This adds `body`. 

`body` is available on `bereq`, `resp`, and `beresp` and is of `Type: BODY` per https://varnish-cache.org/docs/trunk/reference/vcl-var.html

Built and tested locally and works successfully. 




