### PR TITLE
Do not trigger completion on space

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -336,7 +336,7 @@ impl LanguageServer for Backend {
 
                 completion_provider: Some(CompletionOptions {
                     resolve_provider: Some(false),
-                    trigger_characters: Some(vec![".".into(), " ".into(), "(".into()]),
+                    trigger_characters: Some(vec![".".into(), "(".into()]),
                     work_done_progress_options: Default::default(),
                     all_commit_characters: None,
                     completion_item: None,


### PR DESCRIPTION
Triggering completion on space make completion way too disturbing. Especially in vim on linefeed on indented code.