### PR TITLE
fix(vcl): binary expression precedence

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,11 +26,21 @@ jobs:
           npm ci
           npx tree-sitter generate
 
+      - name: Test tree-sitter-vcl
+        working-directory: ./vendor/tree-sitter-vcl
+        run: |
+          npx tree-sitter test
+
       - name: Generate tree-sitter-vtc
         working-directory: ./vendor/tree-sitter-vtc
         run: |
           npm ci
           npx tree-sitter generate
+
+      - name: Test tree-sitter-vtc
+        working-directory: ./vendor/tree-sitter-vtc
+        run: |
+          npx tree-sitter test
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /target
 /node_modules
 /vendor/tree-sitter-*/src
-
+*.wasm

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ clean:
 	cargo clean
 
 tree-sitter-vcl:
-	cd vendor/tree-sitter-vcl && npm ci && npm run build
+	cd vendor/tree-sitter-vcl && npm ci && npm run build && tree-sitter test
 
 tree-sitter-vtc:
-	cd vendor/tree-sitter-vtc && npm ci && npm run build
+	cd vendor/tree-sitter-vtc && npm ci && npm run build && tree-sitter test
 
 build:
 	cargo build

--- a/src/formatter_queries/main.scm
+++ b/src/formatter_queries/main.scm
@@ -55,7 +55,7 @@
     (COMMENT)
 ] @allow_blank_line_before
 
-(binary_expression (operator [(or) (and)]) @append_empty_softline) (#scope_id! "tuple")
+(binary_expression operator: ["||" "&&"] @append_empty_softline) (#scope_id! "tuple")
 
 (func_call_args
   "(" @append_begin_scope @append_empty_softline @append_indent_start
@@ -66,13 +66,13 @@
 (func_call_args "," @append_empty_softline) (#scope_id! "tuple")
 
 (binary_expression
-    operator: (operator [(add) (multiply)]) @append_indent_start
+    operator: ["+" "-" "*" "/"] @append_indent_start
     right: (_) @append_indent_end
     (#scope_id! "big_maths")
 )
-(binary_expression operator: (operator [(add) (multiply)]) @append_empty_softline) (#scope_id! "big_maths")
+(binary_expression operator: ["+" "-" "*" "/"] @append_empty_softline) (#scope_id! "big_maths")
 
-(operator) @prepend_space @append_space
+(binary_expression operator: _ @prepend_space @append_space)
 
 (COMMENT) @append_hardline @prepend_input_softline @multi_line_indent_all
 (inline_c) @append_hardline @multi_line_indent_all @allow_blank_line_before

--- a/vendor/tree-sitter-vcl/grammar.js
+++ b/vendor/tree-sitter-vcl/grammar.js
@@ -14,7 +14,18 @@ module.exports = grammar({
   extras: $ => [/\s+/, $.COMMENT, $.inline_c],
   inline: $ => [$.expr, $.inline_c],
 
-  precedences: () => [['member', 'call']],
+  precedences: () => [
+    [
+      'member',
+      'call',
+      'binary_times',
+      'binary_plus',
+      'binary_relation',
+      'binary_equality',
+      'logical_and',
+      'logical_or',
+    ],
+  ],
 
   rules: {
     source_file: $ => repeat($.toplev_declaration),
@@ -203,7 +214,7 @@ module.exports = grammar({
       choice(
         $.literal,
         $.ident_call_expr,
-        prec('member', $.nested_ident),
+        $.nested_ident, 
         $.parenthesized_expression,
         $.binary_expression,
         $.neg_expr,
@@ -212,14 +223,31 @@ module.exports = grammar({
     parenthesized_expression: $ => seq('(', $.expr, ')'),
 
     binary_expression: $ =>
-      prec.left(
-        seq(
-          field('left', $.expr),
-          field('operator', $.operator),
-          field('right', $.expr),
+      choice(
+        ...[
+          ['&&', 'logical_and'],
+          ['||', 'logical_or'],
+          ['+', 'binary_plus'],
+          ['-', 'binary_plus'],
+          ['*', 'binary_times'],
+          ['/', 'binary_times'],
+          ['<', 'binary_relation'],
+          ['<=', 'binary_relation'],
+          ['==', 'binary_equality'],
+          ['!=', 'binary_equality'],
+          ['>=', 'binary_relation'],
+          ['>', 'binary_relation'],
+        ].map(([operator, precedence]) =>
+          prec.left(
+            precedence,
+            seq(
+              field('left', choice($.expr)), 
+              field('operator', operator),
+              field('right', choice($.expr)),
+            ),
+          ),
         ),
       ),
-
     neg_expr: $ => prec.left(seq('!', $.expr)),
 
     bool: () => choice('true', 'false'),

--- a/vendor/tree-sitter-vcl/grammar.js
+++ b/vendor/tree-sitter-vcl/grammar.js
@@ -21,6 +21,7 @@ module.exports = grammar({
       'binary_times',
       'binary_plus',
       'binary_relation',
+      'binary_match',
       'binary_equality',
       'logical_and',
       'logical_or',
@@ -214,7 +215,7 @@ module.exports = grammar({
       choice(
         $.literal,
         $.ident_call_expr,
-        $.nested_ident, 
+        $.nested_ident,
         $.parenthesized_expression,
         $.binary_expression,
         $.neg_expr,
@@ -237,11 +238,13 @@ module.exports = grammar({
           ['!=', 'binary_equality'],
           ['>=', 'binary_relation'],
           ['>', 'binary_relation'],
+          ['~', 'binary_match'],
+          ['!~', 'binary_match'],
         ].map(([operator, precedence]) =>
           prec.left(
             precedence,
             seq(
-              field('left', choice($.expr)), 
+              field('left', choice($.expr)),
               field('operator', operator),
               field('right', choice($.expr)),
             ),
@@ -253,35 +256,6 @@ module.exports = grammar({
     bool: () => choice('true', 'false'),
     add: () => choice('+', '-'),
     multiply: () => choice('*', '/'),
-
-    eq: () => '==',
-    ne: () => '!=',
-    rmatch: () => '~', // regex or acl
-    nmatch: () => '!~',
-    g: () => '>',
-    l: () => '<',
-    ge: () => '>=',
-    le: () => '<=',
-    // not: ($) => '!',
-    or: () => '||',
-    and: () => '&&',
-
-    operator: $ =>
-      choice(
-        $.add,
-        $.multiply,
-        $.and,
-        $.or,
-        $.eq,
-        $.ne,
-        $.rmatch,
-        $.nmatch,
-        // $.not,
-        $.g,
-        $.l,
-        $.ge,
-        $.le,
-      ),
 
     literal: $ => choice($.string, $.duration, $.bytes, $.number, $.bool),
     string: () =>

--- a/vendor/tree-sitter-vcl/queries/highlights.scm
+++ b/vendor/tree-sitter-vcl/queries/highlights.scm
@@ -34,9 +34,24 @@
   "ok"
 ] @keyword
 
-(operator) @operator
-"=" @operator
-"!" @operator
+[
+  "=="
+  "!="
+  "~"
+  "!~"
+  ">"
+  "<"
+  ">="
+  "<="
+  "||"
+  "&&"
+  "+"
+  "-"
+  "*"
+  "/"
+  "="
+  "!"
+] @operator
 
 [
   "."
@@ -72,7 +87,11 @@
 ] @variable.builtin
 
 (binary_expression
-  operator: (operator (rmatch))
+  operator: "~"
+  right: (literal (string) @string.regex (#offset! @string.regex 0 1 0 -1)))
+
+(binary_expression
+  operator: "!~"
   right: (literal (string) @string.regex (#offset! @string.regex 0 1 0 -1)))
 
 (func_call_named_arg

--- a/vendor/tree-sitter-vcl/queries/injections.scm
+++ b/vendor/tree-sitter-vcl/queries/injections.scm
@@ -1,9 +1,9 @@
 (COMMENT) @comment
 (binary_expression
-  operator: (operator (rmatch))
+  operator: "~"
   right: (literal (string) @regex (#offset! @regex 0 1 0 -1)))
 (binary_expression
-  operator: (operator (nmatch))
+  operator: "!~"
   right: (literal (string) @regex (#offset! @regex 0 1 0 -1)))
 ((inline_c) @c (#offset! @c 0 2 0 -2))
 (ident_call_expr

--- a/vendor/tree-sitter-vcl/queries/semantic_tokens.scm
+++ b/vendor/tree-sitter-vcl/queries/semantic_tokens.scm
@@ -35,9 +35,25 @@
   "ok"
 ] @keyword
 
-(operator) @operator
-"=" @operator
-"!" @operator
+[
+  "=="
+  "!="
+  "~"
+  "!~"
+  ">"
+  "<"
+  ">="
+  "<="
+  "||"
+  "&&"
+  "+"
+  "-"
+  "*"
+  "/"
+  "="
+  "!"
+] @operator
+
 "." @operator
 ; [ "(" ")" ";"] @delimiter
 
@@ -53,9 +69,12 @@
 (nested_ident) @property
 
 (binary_expression
-  operator: (operator (rmatch))
+  operator: "~"
   right: (literal (string) @regexp (#offset! @regexp 0 1 0 -1)))
 
+(binary_expression
+  operator: "!~"
+  right: (literal (string) @regexp (#offset! @regexp 0 1 0 -1)))
 
 
 (ident_call_expr

--- a/vendor/tree-sitter-vcl/test/corpus/binary-expression.txt
+++ b/vendor/tree-sitter-vcl/test/corpus/binary-expression.txt
@@ -1,0 +1,100 @@
+==================
+Binary expression precidence simple
+==================
+
+sub vcl_recv {
+    if (1 == 1 || 3 == 3) {
+    }
+}
+
+---
+
+    (source_file
+      (toplev_declaration
+        (sub_declaration
+          (ident)
+          (block
+            (stmt
+              (if_stmt
+                (parenthesized_expression
+                  (binary_expression
+                    (binary_expression
+                      (literal
+                        (number))
+                      (literal
+                        (number)))
+                    (binary_expression
+                      (literal
+                        (number))
+                      (literal
+                        (number)))))
+                (block)))))))
+
+
+==================
+Binary expression precidence with real world exaple
+==================
+
+sub vcl_recv {
+    if (req.http.method == "GET" && req.http.url == "/api") {
+    }
+}
+
+---
+
+    (source_file
+      (toplev_declaration
+        (sub_declaration
+          (ident)
+          (block
+            (stmt
+              (if_stmt
+                (parenthesized_expression
+                  (binary_expression
+                    (binary_expression
+                      (nested_ident)
+                      (literal
+                        (string)))
+                    (binary_expression
+                      (nested_ident)
+                      (literal
+                        (string)))))  
+                (block)))))))
+
+
+==================
+Binary expression precidence complex
+==================
+
+sub vcl_recv {
+    if ((req.http.method == "GET" && req.http.url == "/api") || 1 == 2) {
+    }
+}
+
+---
+
+ (source_file
+      (toplev_declaration
+        (sub_declaration
+          (ident)
+          (block
+            (stmt
+              (if_stmt
+                (parenthesized_expression
+                  (binary_expression
+                    (parenthesized_expression
+                      (binary_expression
+                        (binary_expression
+                          (nested_ident)
+                          (literal
+                            (string)))
+                        (binary_expression
+                          (nested_ident)
+                          (literal
+                            (string)))))
+                    (binary_expression
+                      (literal
+                        (number))
+                      (literal
+                        (number)))))
+                (block)))))))

--- a/vendor/tree-sitter-vcl/test/corpus/binary-expression.txt
+++ b/vendor/tree-sitter-vcl/test/corpus/binary-expression.txt
@@ -9,58 +9,56 @@ sub vcl_recv {
 
 ---
 
-    (source_file
-      (toplev_declaration
-        (sub_declaration
-          (ident)
-          (block
-            (stmt
-              (if_stmt
-                (parenthesized_expression
-                  (binary_expression
-                    (binary_expression
-                      (literal
-                        (number))
-                      (literal
-                        (number)))
-                    (binary_expression
-                      (literal
-                        (number))
-                      (literal
-                        (number)))))
-                (block)))))))
-
+(source_file
+  (toplev_declaration
+    (sub_declaration
+      (ident)
+      (block
+        (stmt
+          (if_stmt
+            (parenthesized_expression
+              (binary_expression
+                (binary_expression
+                  (literal
+                    (number))
+                  (literal
+                    (number)))
+                (binary_expression
+                  (literal
+                    (number))
+                  (literal
+                    (number)))))
+            (block)))))))
 
 ==================
 Binary expression precidence with real world exaple
 ==================
 
 sub vcl_recv {
-    if (req.http.method == "GET" && req.http.url == "/api") {
+    if (req.http.method == "GET" && req.http.url ~ "/api") {
     }
 }
 
 ---
 
-    (source_file
-      (toplev_declaration
-        (sub_declaration
-          (ident)
-          (block
-            (stmt
-              (if_stmt
-                (parenthesized_expression
-                  (binary_expression
-                    (binary_expression
-                      (nested_ident)
-                      (literal
-                        (string)))
-                    (binary_expression
-                      (nested_ident)
-                      (literal
-                        (string)))))  
-                (block)))))))
-
+(source_file
+  (toplev_declaration
+    (sub_declaration
+      (ident)
+      (block
+        (stmt
+          (if_stmt
+            (parenthesized_expression
+              (binary_expression
+                (binary_expression
+                  (nested_ident)
+                  (literal
+                    (string)))
+                (binary_expression
+                  (nested_ident)
+                  (literal
+                    (string)))))
+            (block)))))))
 
 ==================
 Binary expression precidence complex
@@ -73,28 +71,28 @@ sub vcl_recv {
 
 ---
 
- (source_file
-      (toplev_declaration
-        (sub_declaration
-          (ident)
-          (block
-            (stmt
-              (if_stmt
+(source_file
+  (toplev_declaration
+    (sub_declaration
+      (ident)
+      (block
+        (stmt
+          (if_stmt
+            (parenthesized_expression
+              (binary_expression
                 (parenthesized_expression
                   (binary_expression
-                    (parenthesized_expression
-                      (binary_expression
-                        (binary_expression
-                          (nested_ident)
-                          (literal
-                            (string)))
-                        (binary_expression
-                          (nested_ident)
-                          (literal
-                            (string)))))
                     (binary_expression
+                      (nested_ident)
                       (literal
-                        (number))
+                        (string)))
+                    (binary_expression
+                      (nested_ident)
                       (literal
-                        (number)))))
-                (block)))))))
+                        (string)))))
+                (binary_expression
+                  (literal
+                    (number))
+                  (literal
+                    (number)))))
+            (block)))))))

--- a/vendor/tree-sitter-vtc/queries/highlights.scm
+++ b/vendor/tree-sitter-vtc/queries/highlights.scm
@@ -26,6 +26,7 @@
   "logexpect"
   "tls_config"
   "tls_handshake"
+  "recv"
   "send"
   "vtest"
   "cond"
@@ -33,6 +34,9 @@
   "sync"
   "deplay"
   "expect_close"
+  "tunnel"
+  "pause"
+  "resume"
 ] @keyword
 
 "<undef>" @constant


### PR DESCRIPTION
Binary expression precedence was not correct as it only went left to right. This aims to improve that by adding more precedence information to nodes in the expression.

**Changes:**
* Adding tests to not let this be broken in the future
* Changed how precedence works in binary expressions

**How to test:**
1. Take the `grammar.js` from the main branch (run the tests with the previous grammar). 
2. Look at the output and you can see that the previous binary expression structure does not make sense 